### PR TITLE
Add Cloudflare blog automation workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# URL of the Cloudflare blog RSS feed to monitor
+CF_BLOG_FEED=https://blog.cloudflare.com/rss/
+
+# Path to the SQLite database file for storing processed articles
+CF_BLOG_DB=cloudflare_blog.db
+
+# OpenAI API key used to generate Chinese summaries
+OPENAI_API_KEY=sk-your-key
+
+# WeCom robot webhook URL for delivering the summaries
+WECOM_WEBHOOK=https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=your-key

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+cloudflare_blog.db
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY src ./src
+
+CMD ["python", "src/main.py"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,97 @@
-# cloudflare_rss
+# Cloudflare Blog 自动化播报机器人
+
+该项目提供一个可部署的工作流，用于自动监控 Cloudflare Blog RSS、拉取原文、生成中文简报，并通过企业微信机器人推送到团队群。
+
+## 功能流程
+
+1. **轮询 RSS**：使用 `feedparser` 获取 Cloudflare Blog 最新文章。
+2. **去重入库**：使用 SQLite 记录已处理文章，避免重复推送。
+3. **抓取正文**：下载博客 HTML 并提取主要内容。
+4. **AI 简报**：调用 OpenAI API（或使用内置回退逻辑）生成中文摘要。
+5. **消息推送**：通过企业微信 Webhook 发送 Markdown 消息，包含摘要与原文链接。
+
+## 快速开始
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env
+# 编辑 .env 设置 OPENAI_API_KEY 与 WECOM_WEBHOOK
+python src/main.py
+```
+
+运行脚本后会自动创建/更新 SQLite 数据库 `cloudflare_blog.db` 并推送新增文章。
+
+## 配置项
+
+通过环境变量或 `.env` 文件（例如使用 `direnv` / `docker` 传入）配置：
+
+| 变量名 | 说明 |
+| --- | --- |
+| `CF_BLOG_FEED` | RSS 地址，默认 `https://blog.cloudflare.com/rss/` |
+| `CF_BLOG_DB` | SQLite 数据库存储路径 |
+| `OPENAI_API_KEY` | OpenAI API Key，用于生成中文摘要 |
+| `WECOM_WEBHOOK` | 企业微信机器人 webhook URL |
+
+## 部署建议
+
+### 1. 定时任务
+
+* **Cron / systemd timer**：在 Linux 服务器上创建 cron 任务，每 10 分钟运行一次 `python /app/src/main.py`。
+* **GitHub Actions / Cloudflare Workers Cron Triggers**：如果希望云端运行，可将项目容器化并部署到支持定时任务的平台。
+
+### 2. 容器化
+
+建议使用 Docker 镜像部署，示例 `Dockerfile` 如下：
+
+```dockerfile
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY src ./src
+
+CMD ["python", "src/main.py"]
+```
+
+构建并运行：
+
+```bash
+docker build -t cloudflare-rss-bot .
+docker run --env-file .env -v $(pwd)/data:/app/data cloudflare-rss-bot
+```
+
+将 `CF_BLOG_DB` 设置为 `/app/data/cloudflare_blog.db` 可实现持久化。
+
+### 3. 环境安全
+
+* 使用密钥管理服务（如 1Password Connect、AWS Secrets Manager）注入 `OPENAI_API_KEY` 与 `WECOM_WEBHOOK`。
+* 为运行容器的机器限制网络访问，仅允许访问 Cloudflare Blog、OpenAI API 与企业微信域名。
+
+### 4. 监控与告警
+
+* 将日志输出重定向到集中式日志系统（如 CloudWatch、ELK）。
+* 为企业微信推送失败设置重试或告警逻辑，以保证重要信息送达。
+
+## 结构
+
+```
+src/
+├── cloudflare_bot/
+│   ├── article.py        # 抓取与解析正文
+│   ├── config.py         # 读取环境配置
+│   ├── notifier.py       # 企业微信推送
+│   ├── rss.py            # RSS 解析
+│   ├── storage.py        # SQLite 持久化
+│   ├── summarizer.py     # 中文摘要生成
+│   └── __init__.py
+└── main.py               # 工作流入口
+```
+
+## 后续扩展
+
+* 将摘要与原文存入知识库，支持历史检索。
+* 引入异步队列（Celery/Cloud Tasks）处理高并发推送。
+* 对接更多渠道（邮件、飞书等）分发摘要。

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+beautifulsoup4==4.12.3
+feedparser==6.0.11
+openai>=1.30.0
+requests==2.31.0

--- a/src/cloudflare_bot/__init__.py
+++ b/src/cloudflare_bot/__init__.py
@@ -1,0 +1,10 @@
+"""Automation utilities for monitoring the Cloudflare Blog RSS feed."""
+
+__all__ = [
+    "config",
+    "rss",
+    "article",
+    "storage",
+    "summarizer",
+    "notifier",
+]

--- a/src/cloudflare_bot/article.py
+++ b/src/cloudflare_bot/article.py
@@ -1,0 +1,57 @@
+"""Utilities for downloading Cloudflare Blog posts and extracting clean text."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import requests
+from bs4 import BeautifulSoup
+
+LOGGER = logging.getLogger(__name__)
+
+
+def fetch_article_html(url: str, timeout: int = 20) -> str:
+    """Download the raw HTML for a blog post."""
+
+    response = requests.get(url, timeout=timeout)
+    response.raise_for_status()
+    return response.text
+
+
+def extract_main_text(html: str) -> str:
+    """Extract readable article text from a Cloudflare Blog HTML page."""
+
+    soup = BeautifulSoup(html, "html.parser")
+    article_tag = soup.find("article") or soup.find("main") or soup
+
+    paragraphs = []
+    for element in article_tag.find_all(["p", "li"]):
+        text = element.get_text(strip=True)
+        if text:
+            paragraphs.append(text)
+
+    # Fallback to any paragraph content if the article tag did not produce text
+    if not paragraphs:
+        for element in soup.find_all("p"):
+            text = element.get_text(strip=True)
+            if text:
+                paragraphs.append(text)
+
+    return "\n\n".join(paragraphs)
+
+
+def get_article_text(url: str, timeout: int = 20) -> Optional[str]:
+    """Convenience helper to retrieve and extract article text."""
+
+    try:
+        html = fetch_article_html(url, timeout=timeout)
+    except requests.RequestException as exc:  # pragma: no cover - network failure
+        LOGGER.warning("Failed to download article %s: %s", url, exc)
+        return None
+
+    text = extract_main_text(html)
+    if not text:
+        LOGGER.warning("No textual content extracted from %s", url)
+        return None
+    return text

--- a/src/cloudflare_bot/config.py
+++ b/src/cloudflare_bot/config.py
@@ -1,0 +1,32 @@
+"""Configuration helpers for the Cloudflare Blog automation bot."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+
+DEFAULT_FEED_URL = "https://blog.cloudflare.com/rss/"
+DEFAULT_DATABASE_PATH = "cloudflare_blog.db"
+
+
+@dataclass(slots=True)
+class Settings:
+    """Runtime configuration loaded from environment variables."""
+
+    feed_url: str = DEFAULT_FEED_URL
+    database_path: str = DEFAULT_DATABASE_PATH
+    openai_api_key: Optional[str] = None
+    wecom_webhook: Optional[str] = None
+
+    @classmethod
+    def from_env(cls) -> "Settings":
+        """Create settings from environment variables."""
+
+        return cls(
+            feed_url=os.getenv("CF_BLOG_FEED", DEFAULT_FEED_URL),
+            database_path=os.getenv("CF_BLOG_DB", DEFAULT_DATABASE_PATH),
+            openai_api_key=os.getenv("OPENAI_API_KEY"),
+            wecom_webhook=os.getenv("WECOM_WEBHOOK"),
+        )

--- a/src/cloudflare_bot/notifier.py
+++ b/src/cloudflare_bot/notifier.py
@@ -1,0 +1,30 @@
+"""Webhook integration for sending summaries to a WeCom robot."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import requests
+
+
+class NotificationError(RuntimeError):
+    """Raised when the WeCom webhook call fails."""
+
+
+def send_wecom_message(summary: str, link: str, webhook_url: Optional[str]) -> None:
+    """Send the generated summary to the configured WeCom webhook."""
+
+    if not webhook_url:
+        raise NotificationError("WeCom webhook URL is not configured")
+
+    payload = {
+        "msgtype": "markdown",
+        "markdown": {
+            "content": f"{summary}\n\n[阅读原文]({link})",
+        },
+    }
+    response = requests.post(webhook_url, json=payload, timeout=10)
+    if response.status_code != 200 or response.json().get("errcode") != 0:
+        raise NotificationError(
+            f"Failed to send notification: {response.status_code} {response.text}"
+        )

--- a/src/cloudflare_bot/rss.py
+++ b/src/cloudflare_bot/rss.py
@@ -1,0 +1,54 @@
+"""Utilities for retrieving and parsing the Cloudflare Blog RSS feed."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable, List
+
+import feedparser
+
+
+@dataclass(slots=True)
+class FeedEntry:
+    """Structured representation of a single RSS feed entry."""
+
+    id: str
+    title: str
+    link: str
+    published: datetime
+
+
+def parse_feed(feed_url: str) -> List[FeedEntry]:
+    """Fetch and parse the RSS feed, returning the most recent entries."""
+
+    parsed = feedparser.parse(feed_url)
+    entries: List[FeedEntry] = []
+    for entry in parsed.entries:
+        published = _normalise_published(entry)
+        entries.append(
+            FeedEntry(
+                id=getattr(entry, "id", entry.link),
+                title=entry.title,
+                link=entry.link,
+                published=published,
+            )
+        )
+    return entries
+
+
+def _normalise_published(entry: feedparser.FeedParserDict) -> datetime:
+    """Convert the RSS published metadata into a ``datetime`` object."""
+
+    if hasattr(entry, "published_parsed") and entry.published_parsed:
+        return datetime(*entry.published_parsed[:6])
+    if hasattr(entry, "updated_parsed") and entry.updated_parsed:
+        return datetime(*entry.updated_parsed[:6])
+    return datetime.utcnow()
+
+
+def filter_new_entries(entries: Iterable[FeedEntry], existing_ids: Iterable[str]) -> List[FeedEntry]:
+    """Return feed entries that do not already exist in the provided IDs."""
+
+    existing = set(existing_ids)
+    return [entry for entry in entries if entry.id not in existing]

--- a/src/cloudflare_bot/storage.py
+++ b/src/cloudflare_bot/storage.py
@@ -1,0 +1,82 @@
+"""SQLite persistence for tracking processed Cloudflare Blog posts."""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Iterator, Optional
+
+
+@dataclass(slots=True)
+class ArticleRecord:
+    """Representation of an article stored in the database."""
+
+    id: str
+    title: str
+    link: str
+    published: datetime
+    summary_zh: Optional[str]
+
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS articles (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    link TEXT NOT NULL,
+    published TEXT NOT NULL,
+    summary_zh TEXT,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+"""
+
+
+@contextmanager
+def connect(path: str) -> Iterator[sqlite3.Connection]:
+    """Context manager returning a SQLite connection with foreign keys enabled."""
+
+    db_path = Path(path)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(db_path)
+    try:
+        connection.execute("PRAGMA foreign_keys = ON;")
+        yield connection
+    finally:
+        connection.commit()
+        connection.close()
+
+
+def initialize_database(path: str) -> None:
+    """Create the necessary database tables if they do not exist."""
+
+    with connect(path) as conn:
+        conn.executescript(SCHEMA)
+
+
+def get_known_ids(path: str) -> Iterable[str]:
+    """Return the IDs of articles that already exist in storage."""
+
+    with connect(path) as conn:
+        cursor = conn.execute("SELECT id FROM articles")
+        return [row[0] for row in cursor.fetchall()]
+
+
+def save_article(path: str, article: ArticleRecord) -> None:
+    """Persist a processed article to the database."""
+
+    with connect(path) as conn:
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO articles (id, title, link, published, summary_zh)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                article.id,
+                article.title,
+                article.link,
+                article.published.isoformat(),
+                article.summary_zh,
+            ),
+        )

--- a/src/cloudflare_bot/summarizer.py
+++ b/src/cloudflare_bot/summarizer.py
@@ -1,0 +1,53 @@
+"""Summarisation utilities for generating Chinese briefs of Cloudflare posts."""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Optional
+
+try:  # pragma: no cover - optional dependency
+    from openai import OpenAI
+except Exception:  # pragma: no cover - optional dependency
+    OpenAI = None  # type: ignore
+
+
+def generate_brief(
+    title: str,
+    content: str,
+    openai_api_key: Optional[str] = None,
+    model: str = "gpt-4o-mini",
+) -> str:
+    """Generate a concise Chinese brief for the article."""
+
+    # Prefer LLM if credentials are provided
+    api_key = openai_api_key or os.getenv("OPENAI_API_KEY")
+    if api_key and OpenAI is not None:
+        client = OpenAI(api_key=api_key)
+        prompt = (
+            "请阅读以下 Cloudflare 博客文章内容，"
+            "用简洁的中文撰写一段 3-5 句的摘要，突出核心问题、解决方案和影响。"
+            "摘要应包含一个合适的标题。文章标题："
+            f"{title}\n\n正文：\n{content[:6000]}"
+        )
+        response = client.responses.create(
+            model=model,
+            input=[{"role": "user", "content": prompt}],
+        )
+        completion = response.output_text.strip()
+        if completion:
+            return completion
+
+    # Fallback heuristic summarisation if no API key is available
+    sentences = _split_sentences(content)
+    preview = "".join(sentences[:3]).strip()
+    if not preview:
+        preview = content[:280]
+    return f"《{title}》摘要：{preview}"
+
+
+def _split_sentences(text: str) -> list[str]:
+    """Split text into sentences by punctuation for the fallback summariser."""
+
+    parts = re.split(r"(?<=[。！？])\s+", text)
+    return [part.strip() for part in parts if part.strip()]

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,52 @@
+"""Entry point for the Cloudflare Blog automation workflow."""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+from cloudflare_bot import article, config, notifier, rss, storage, summarizer
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+LOGGER = logging.getLogger(__name__)
+
+
+def process_entries(entries: Iterable[rss.FeedEntry], settings: config.Settings) -> None:
+    """Process RSS entries, persisting new ones and notifying WeCom."""
+
+    for entry in entries:
+        LOGGER.info("Processing entry: %s", entry.title)
+        content = article.get_article_text(entry.link)
+        if not content:
+            LOGGER.warning("Skipping %s due to missing content", entry.link)
+            continue
+
+        summary = summarizer.generate_brief(entry.title, content, settings.openai_api_key)
+        record = storage.ArticleRecord(
+            id=entry.id,
+            title=entry.title,
+            link=entry.link,
+            published=entry.published,
+            summary_zh=summary,
+        )
+        storage.save_article(settings.database_path, record)
+
+        try:
+            notifier.send_wecom_message(summary, entry.link, settings.wecom_webhook)
+        except notifier.NotificationError as exc:
+            LOGGER.error("Failed to send notification for %s: %s", entry.link, exc)
+
+
+def main() -> None:
+    settings = config.Settings.from_env()
+    storage.initialize_database(settings.database_path)
+
+    entries = rss.parse_feed(settings.feed_url)
+    known_ids = storage.get_known_ids(settings.database_path)
+    new_entries = rss.filter_new_entries(entries, known_ids)
+    LOGGER.info("Found %d new entries", len(new_entries))
+    process_entries(new_entries, settings)
+
+
+if __name__ == "__main__":  # pragma: no cover - script entrypoint
+    main()


### PR DESCRIPTION
## Summary
- add a Python-based workflow that monitors the Cloudflare Blog RSS feed and processes new posts
- implement modules for article fetching, SQLite storage, AI summarisation with fallback, and WeCom webhook delivery
- document configuration and deployment steps, provide Docker image, environment template, and dependencies list

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_b_68d637add4ec832ca8bfa36f244dc4cb