### PR TITLE
feat: allow configuring custom llm endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,41 @@ python src/main.py
 | `CF_BLOG_FEED` | RSS 地址，默认 `https://blog.cloudflare.com/rss/` |
 | `CF_BLOG_DB` | SQLite 数据库存储路径 |
 | `OPENAI_API_KEY` | OpenAI API Key，用于生成中文摘要 |
+| `LLM_API_URL` | （可选）自定义 LLM HTTP 接口地址，设置后将优先使用该接口 |
+| `LLM_API_KEY` | （可选）自定义 LLM 的鉴权 Token，将自动加到 `Authorization: Bearer` 头中 |
+| `LLM_MODEL` | （可选）自定义 LLM 模型名称；对 OpenAI 与自定义接口同时生效 |
+| `LLM_MESSAGE_KEY` | （可选）自定义接口中承载对话内容的字段名，默认为 `messages` |
 | `WECOM_WEBHOOK` | 企业微信机器人 webhook URL |
 | `CF_BLOG_INITIAL_SUMMARY_LIMIT` | 首次同步时生成并推送摘要的最大文章数，默认为 5 |
+
+### 使用自定义 LLM 接口
+
+当需要接入非 OpenAI 的模型服务时，只需提供兼容的 HTTP Chat Completion 接口。例如以下 EdgeFn API：
+
+```python
+import requests
+
+url = "https://api.edgefn.net/v1/chat/completions"
+headers = {
+    "Authorization": "Bearer <YOUR_API_KEY>",
+    "Content-Type": "application/json",
+}
+data = {
+    "model": "Qwen3-Next-80B-A3B-Instruct",
+    "messages": [{"role": "user", "content": "Hello"}],
+}
+```
+
+在 `.env` 中设置：
+
+```dotenv
+LLM_API_URL=https://api.edgefn.net/v1/chat/completions
+LLM_API_KEY=<YOUR_API_KEY>
+LLM_MODEL=Qwen3-Next-80B-A3B-Instruct
+LLM_MESSAGE_KEY=messages
+```
+
+程序会按照上述配置自动构造 `POST` 请求并解析常见的 `choices[].message.content`、`choices[].text`、`output_text` 等字段返回的摘要。如果接口返回非标准结构，可在 `_extract_text_from_response` 中扩展解析逻辑。
 
 ## 部署建议
 

--- a/src/cloudflare_bot/config.py
+++ b/src/cloudflare_bot/config.py
@@ -18,6 +18,10 @@ class Settings:
     feed_url: str = DEFAULT_FEED_URL
     database_path: str = DEFAULT_DATABASE_PATH
     openai_api_key: Optional[str] = None
+    llm_api_url: Optional[str] = None
+    llm_api_key: Optional[str] = None
+    llm_model: Optional[str] = None
+    llm_message_key: str = "messages"
     wecom_webhook: Optional[str] = None
     initial_summary_limit: int = DEFAULT_INITIAL_SUMMARY_LIMIT
 
@@ -29,6 +33,10 @@ class Settings:
             feed_url=os.getenv("CF_BLOG_FEED", DEFAULT_FEED_URL),
             database_path=os.getenv("CF_BLOG_DB", DEFAULT_DATABASE_PATH),
             openai_api_key=os.getenv("OPENAI_API_KEY"),
+            llm_api_url=os.getenv("LLM_API_URL"),
+            llm_api_key=os.getenv("LLM_API_KEY"),
+            llm_model=os.getenv("LLM_MODEL"),
+            llm_message_key=os.getenv("LLM_MESSAGE_KEY", "messages"),
             wecom_webhook=os.getenv("WECOM_WEBHOOK"),
             initial_summary_limit=_get_int(
                 "CF_BLOG_INITIAL_SUMMARY_LIMIT", DEFAULT_INITIAL_SUMMARY_LIMIT

--- a/src/cloudflare_bot/summarizer.py
+++ b/src/cloudflare_bot/summarizer.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import os
 import re
-from typing import Optional
+from typing import Any, Optional
+
+import requests
 
 try:  # pragma: no cover - optional dependency
     from openai import OpenAI
@@ -17,19 +19,40 @@ def generate_brief(
     content: str,
     openai_api_key: Optional[str] = None,
     model: str = "gpt-4o-mini",
+    custom_api_url: Optional[str] = None,
+    custom_api_key: Optional[str] = None,
+    custom_model: Optional[str] = None,
+    custom_message_key: str = "messages",
 ) -> str:
     """Generate a concise Chinese brief for the article."""
 
     # Prefer LLM if credentials are provided
+    prompt = (
+        "请阅读以下 Cloudflare 博客文章内容，"
+        "用简洁的中文撰写一段 3-5 句的摘要，突出核心问题、解决方案和影响。"
+        "摘要应包含一个合适的标题。文章标题："
+        f"{title}\n\n正文：\n{content[:6000]}"
+    )
+
     api_key = openai_api_key or os.getenv("OPENAI_API_KEY")
+    custom_url = custom_api_url or os.getenv("LLM_API_URL")
+    custom_key = custom_api_key or os.getenv("LLM_API_KEY")
+    custom_model_name = custom_model or os.getenv("LLM_MODEL") or model
+    message_key = custom_message_key or os.getenv("LLM_MESSAGE_KEY") or "messages"
+
+    if custom_url:
+        completion = _call_custom_llm(
+            prompt,
+            custom_url,
+            custom_key,
+            custom_model_name,
+            message_key,
+        )
+        if completion:
+            return completion
+
     if api_key and OpenAI is not None:
         client = OpenAI(api_key=api_key)
-        prompt = (
-            "请阅读以下 Cloudflare 博客文章内容，"
-            "用简洁的中文撰写一段 3-5 句的摘要，突出核心问题、解决方案和影响。"
-            "摘要应包含一个合适的标题。文章标题："
-            f"{title}\n\n正文：\n{content[:6000]}"
-        )
         response = client.responses.create(
             model=model,
             input=[{"role": "user", "content": prompt}],
@@ -51,3 +74,69 @@ def _split_sentences(text: str) -> list[str]:
 
     parts = re.split(r"(?<=[。！？])\s+", text)
     return [part.strip() for part in parts if part.strip()]
+
+
+def _call_custom_llm(
+    prompt: str,
+    api_url: str,
+    api_key: Optional[str],
+    model: str,
+    message_key: str,
+) -> Optional[str]:
+    """Send the prompt to a custom LLM HTTP endpoint."""
+
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    payload: dict[str, Any] = {"model": model, message_key: [{"role": "user", "content": prompt}]}
+
+    try:
+        response = requests.post(api_url, headers=headers, json=payload, timeout=30)
+        response.raise_for_status()
+    except requests.RequestException:
+        return None
+
+    try:
+        data = response.json()
+    except ValueError:
+        return None
+
+    completion = _extract_text_from_response(data)
+    if completion:
+        return completion.strip()
+    return None
+
+
+def _extract_text_from_response(data: Any) -> Optional[str]:
+    """Extract assistant text from a generic chat completion response."""
+
+    if isinstance(data, dict):
+        output_text = data.get("output_text")
+        if isinstance(output_text, str):
+            return output_text
+
+        choices = data.get("choices")
+        if isinstance(choices, list):
+            for choice in choices:
+                if not isinstance(choice, dict):
+                    continue
+                message = choice.get("message") or choice.get("delta")
+                if isinstance(message, dict):
+                    content = message.get("content")
+                    if isinstance(content, str):
+                        return content
+                    if isinstance(content, list):
+                        parts = [part.get("text") for part in content if isinstance(part, dict)]
+                        joined = "".join(part for part in parts if isinstance(part, str))
+                        if joined:
+                            return joined
+                content = choice.get("text")
+                if isinstance(content, str):
+                    return content
+
+        result = data.get("result")
+        if isinstance(result, str):
+            return result
+
+    return None

--- a/src/main.py
+++ b/src/main.py
@@ -21,7 +21,17 @@ def process_entries(entries: Iterable[rss.FeedEntry], settings: config.Settings)
             LOGGER.warning("Skipping %s due to missing content", entry.link)
             continue
 
-        summary = summarizer.generate_brief(entry.title, content, settings.openai_api_key)
+        model_name = settings.llm_model or "gpt-4o-mini"
+        summary = summarizer.generate_brief(
+            entry.title,
+            content,
+            openai_api_key=settings.openai_api_key,
+            model=model_name,
+            custom_api_url=settings.llm_api_url,
+            custom_api_key=settings.llm_api_key,
+            custom_model=settings.llm_model,
+            custom_message_key=settings.llm_message_key,
+        )
         record = storage.ArticleRecord(
             id=entry.id,
             title=entry.title,


### PR DESCRIPTION
## Summary
- add configuration options for custom chat completion endpoints and message key
- extend the summariser to call configurable HTTP LLMs before falling back to OpenAI
- document the new environment variables for integrating alternative providers

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_b_68d658effe5c832c96529cec0428ff35