### PR TITLE
Format WeCom briefs with categories and markdown

### DIFF
--- a/src/cloudflare_bot/notifier.py
+++ b/src/cloudflare_bot/notifier.py
@@ -6,21 +6,41 @@ from typing import Optional
 
 import requests
 
+from . import summarizer
+
 
 class NotificationError(RuntimeError):
     """Raised when the WeCom webhook call fails."""
 
 
-def send_wecom_message(summary: str, link: str, webhook_url: Optional[str]) -> None:
+def send_wecom_message(
+    brief: summarizer.Brief,
+    title: str,
+    link: str,
+    webhook_url: Optional[str],
+) -> None:
     """Send the generated summary to the configured WeCom webhook."""
 
     if not webhook_url:
         raise NotificationError("WeCom webhook URL is not configured")
 
+    category_block = (
+        f"【<font color=\"red\">{brief.category}</font>】" if brief.category else ""
+    )
+    header = f"{category_block}<font color=\"info\">{title}</font>"
+    content_lines = [
+        header,
+        "**简报**",
+        brief.summary,
+        "",
+        f"[原文链接]({link})",
+    ]
+    markdown_content = "\n".join(line for line in content_lines if line is not None)
+
     payload = {
         "msgtype": "markdown",
         "markdown": {
-            "content": f"{summary}\n\n[阅读原文]({link})",
+            "content": markdown_content,
         },
     }
     response = requests.post(webhook_url, json=payload, timeout=10)


### PR DESCRIPTION
## Summary
- add a structured `Brief` object and enhanced parsing so summaries include an article category alongside the Chinese brief
- format WeCom markdown notifications with coloured category and title lines plus a labelled summary and original link
- persist summaries with the category-prefixed title for future reference

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_b_68da49727b5c832c858771027ddc6bf9